### PR TITLE
feat: define ProviderAdapter port interface

### DIFF
--- a/src/domain/ports/adapter.ts
+++ b/src/domain/ports/adapter.ts
@@ -1,20 +1,21 @@
 import type { Doc } from 'yjs'
 import type { Awareness } from 'y-protocols/awareness'
+import type { RoomId } from '../value-objects/room-id.js'
 
 /** Port interface for provider adapters */
 export interface ProviderAdapter {
   /** Create/register a room on the provider */
-  createRoom(roomId: string, ydoc: Doc): Promise<void> | void
+  createRoom(roomId: RoomId, ydoc: Doc): Promise<void>
 
   /** Destroy a room on the provider */
-  destroyRoom(roomId: string): Promise<void> | void
+  destroyRoom(roomId: RoomId): Promise<void>
 
   /** Get the Awareness instance for a room */
-  getAwareness(roomId: string): Awareness | null
+  getAwareness(roomId: RoomId): Awareness | null
 
   /** Subscribe to document updates */
-  onDocUpdate(roomId: string, callback: () => void): () => void
+  onDocUpdate(roomId: RoomId, callback: () => void): () => void
 
   /** Subscribe to awareness updates */
-  onAwarenessUpdate(roomId: string, callback: () => void): () => void
+  onAwarenessUpdate(roomId: RoomId, callback: () => void): () => void
 }


### PR DESCRIPTION
## Summary
- Define `ProviderAdapter` interface as the domain port for transport-layer abstraction (Hocuspocus, y-websocket, etc.)
- Uses `RoomId` value object for type-safe room identification across all methods

## Changes

### Domain port
- Add `src/domain/ports/adapter.ts` with `ProviderAdapter` interface
- 5 methods: `createRoom`, `destroyRoom`, `getAwareness`, `onDocUpdate`, `onAwarenessUpdate`
- All methods use `RoomId` type (not raw string) for room identification
- Async operations (`createRoom`, `destroyRoom`) return `Promise<void>`
- `onDocUpdate` / `onAwarenessUpdate` return unsubscribe functions (`() => void`)

## Notes
- Closes #3
- This interface was originally part of #1 but split into its own PR for better separation of concerns