### PR TITLE
fix: clean up external onDocUpdate subscriptions on Room.destroy()

### DIFF
--- a/src/domain/entities/room.ts
+++ b/src/domain/entities/room.ts
@@ -18,6 +18,7 @@ export class Room {
   private destroyed = false
   private readonly unsubDocUpdate: () => void
   private readonly unsubAwarenessUpdate: () => void
+  private readonly externalDocUpdateUnsubs = new Set<() => void>()
   private readonly awarenessWrapper: AwarenessWrapper
   private readonly provider: ProviderAdapter
   private readonly timer: TtlTimer
@@ -68,7 +69,13 @@ export class Room {
 
   /** Subscribe to document update events. Returns unsubscribe function. */
   onDocUpdate(cb: () => void): () => void {
-    return this.provider.onDocUpdate(this.id, cb)
+    const unsub = this.provider.onDocUpdate(this.id, cb)
+    const wrappedUnsub = () => {
+      this.externalDocUpdateUnsubs.delete(wrappedUnsub)
+      unsub()
+    }
+    this.externalDocUpdateUnsubs.add(wrappedUnsub)
+    return wrappedUnsub
   }
 
   /** Touch the room to reset the TTL */
@@ -83,6 +90,9 @@ export class Room {
 
     this.unsubDocUpdate()
     this.unsubAwarenessUpdate()
+    for (const unsub of this.externalDocUpdateUnsubs) {
+      unsub()
+    }
     this.timer.destroy()
     this.awarenessWrapper.destroy()
     await this.provider.destroyRoom(this.id)

--- a/src/domain/entities/room.ts
+++ b/src/domain/entities/room.ts
@@ -70,9 +70,13 @@ export class Room {
   /** Subscribe to document update events. Returns unsubscribe function. */
   onDocUpdate(cb: () => void): () => void {
     const unsub = this.provider.onDocUpdate(this.id, cb)
+    let called = false
     const wrappedUnsub = () => {
       this.externalDocUpdateUnsubs.delete(wrappedUnsub)
-      unsub()
+      if (!called) {
+        called = true
+        unsub()
+      }
     }
     this.externalDocUpdateUnsubs.add(wrappedUnsub)
     return wrappedUnsub

--- a/src/domain/entities/room.ts
+++ b/src/domain/entities/room.ts
@@ -90,7 +90,9 @@ export class Room {
 
     this.unsubDocUpdate()
     this.unsubAwarenessUpdate()
-    for (const unsub of this.externalDocUpdateUnsubs) {
+    const externalUnsubs = [...this.externalDocUpdateUnsubs]
+    this.externalDocUpdateUnsubs.clear()
+    for (const unsub of externalUnsubs) {
       unsub()
     }
     this.timer.destroy()

--- a/src/domain/entities/room.ts
+++ b/src/domain/entities/room.ts
@@ -69,6 +69,7 @@ export class Room {
 
   /** Subscribe to document update events. Returns unsubscribe function. */
   onDocUpdate(cb: () => void): () => void {
+    if (this.destroyed) throw new Error('Room already destroyed')
     const unsub = this.provider.onDocUpdate(this.id, cb)
     let called = false
     const wrappedUnsub = () => {

--- a/src/domain/entities/room.ts
+++ b/src/domain/entities/room.ts
@@ -72,11 +72,10 @@ export class Room {
     const unsub = this.provider.onDocUpdate(this.id, cb)
     let called = false
     const wrappedUnsub = () => {
+      if (called) return
+      called = true
       this.externalDocUpdateUnsubs.delete(wrappedUnsub)
-      if (!called) {
-        called = true
-        unsub()
-      }
+      unsub()
     }
     this.externalDocUpdateUnsubs.add(wrappedUnsub)
     return wrappedUnsub

--- a/tests/domain/entities/room.test.ts
+++ b/tests/domain/entities/room.test.ts
@@ -209,6 +209,12 @@ describe('Room', () => {
       expect(provider.onDocUpdate).toHaveBeenCalledWith(roomId, cb)
     })
 
+    it('throws if room is already destroyed', async () => {
+      const { room } = createRoom()
+      await room.destroy()
+      expect(() => room.onDocUpdate(vi.fn())).toThrow('Room already destroyed')
+    })
+
     it('calls provider unsubscribe when returned function is called', () => {
       const provider = createMockProvider()
       const providerUnsub = vi.fn()

--- a/tests/domain/entities/room.test.ts
+++ b/tests/domain/entities/room.test.ts
@@ -204,10 +204,23 @@ describe('Room', () => {
       const { room, roomId } = createRoom({ provider })
 
       const cb = vi.fn()
-      const result = room.onDocUpdate(cb)
+      room.onDocUpdate(cb)
 
       expect(provider.onDocUpdate).toHaveBeenCalledWith(roomId, cb)
-      expect(result).toBe(unsub)
+    })
+
+    it('calls provider unsubscribe when returned function is called', () => {
+      const provider = createMockProvider()
+      const providerUnsub = vi.fn()
+      ;(provider.onDocUpdate as ReturnType<typeof vi.fn>).mockReturnValue(
+        providerUnsub,
+      )
+      const { room } = createRoom({ provider })
+
+      const unsub = room.onDocUpdate(vi.fn())
+      unsub()
+
+      expect(providerUnsub).toHaveBeenCalledOnce()
     })
   })
 
@@ -252,6 +265,38 @@ describe('Room', () => {
       const { room, provider, roomId } = createRoom()
       await room.destroy()
       expect(provider.destroyRoom).toHaveBeenCalledWith(roomId)
+    })
+
+    it('unsubscribes external onDocUpdate listeners', async () => {
+      const provider = createMockProvider()
+      const providerUnsub = vi.fn()
+      ;(provider.onDocUpdate as ReturnType<typeof vi.fn>).mockReturnValue(
+        providerUnsub,
+      )
+      const { room } = createRoom({ provider })
+
+      room.onDocUpdate(vi.fn())
+      room.onDocUpdate(vi.fn())
+      await room.destroy()
+
+      // 2 external + 1 internal (constructor) = 3 calls
+      expect(providerUnsub).toHaveBeenCalledTimes(3)
+    })
+
+    it('does not double-unsubscribe manually removed listeners', async () => {
+      const provider = createMockProvider()
+      const providerUnsub = vi.fn()
+      ;(provider.onDocUpdate as ReturnType<typeof vi.fn>).mockReturnValue(
+        providerUnsub,
+      )
+      const { room } = createRoom({ provider })
+
+      const unsub = room.onDocUpdate(vi.fn())
+      unsub() // manual unsubscribe
+      await room.destroy()
+
+      // 1 manual + 1 internal (constructor) = 2 calls
+      expect(providerUnsub).toHaveBeenCalledTimes(2)
     })
 
     it('is idempotent', async () => {

--- a/tests/domain/entities/room.test.ts
+++ b/tests/domain/entities/room.test.ts
@@ -269,34 +269,39 @@ describe('Room', () => {
 
     it('unsubscribes external onDocUpdate listeners', async () => {
       const provider = createMockProvider()
-      const providerUnsub = vi.fn()
-      ;(provider.onDocUpdate as ReturnType<typeof vi.fn>).mockReturnValue(
-        providerUnsub,
-      )
+      const providerUnsubInternal = vi.fn()
+      const providerUnsubExternal1 = vi.fn()
+      const providerUnsubExternal2 = vi.fn()
+      ;(provider.onDocUpdate as ReturnType<typeof vi.fn>)
+        .mockReturnValueOnce(providerUnsubInternal) // internal (constructor)
+        .mockReturnValueOnce(providerUnsubExternal1) // first external
+        .mockReturnValueOnce(providerUnsubExternal2) // second external
       const { room } = createRoom({ provider })
 
       room.onDocUpdate(vi.fn())
       room.onDocUpdate(vi.fn())
       await room.destroy()
 
-      // 2 external + 1 internal (constructor) = 3 calls
-      expect(providerUnsub).toHaveBeenCalledTimes(3)
+      expect(providerUnsubInternal).toHaveBeenCalledTimes(1)
+      expect(providerUnsubExternal1).toHaveBeenCalledTimes(1)
+      expect(providerUnsubExternal2).toHaveBeenCalledTimes(1)
     })
 
     it('does not double-unsubscribe manually removed listeners', async () => {
       const provider = createMockProvider()
-      const providerUnsub = vi.fn()
-      ;(provider.onDocUpdate as ReturnType<typeof vi.fn>).mockReturnValue(
-        providerUnsub,
-      )
+      const providerUnsubInternal = vi.fn()
+      const providerUnsubExternal = vi.fn()
+      ;(provider.onDocUpdate as ReturnType<typeof vi.fn>)
+        .mockReturnValueOnce(providerUnsubInternal) // internal (constructor)
+        .mockReturnValueOnce(providerUnsubExternal) // external
       const { room } = createRoom({ provider })
 
       const unsub = room.onDocUpdate(vi.fn())
       unsub() // manual unsubscribe
       await room.destroy()
 
-      // 1 manual + 1 internal (constructor) = 2 calls
-      expect(providerUnsub).toHaveBeenCalledTimes(2)
+      expect(providerUnsubInternal).toHaveBeenCalledTimes(1)
+      expect(providerUnsubExternal).toHaveBeenCalledTimes(1)
     })
 
     it('is idempotent', async () => {


### PR DESCRIPTION
## Summary
- Track external `onDocUpdate` subscriptions internally and clean them up on `destroy()`, fixing the cleanup asymmetry where `onJoin`/`onLeave`/`onUpdate` were cleaned up but `onDocUpdate` was not

## Related Issue
Closes #33

## Changes

### Domain: Room entity (`src/domain/entities/room.ts`)
- Add `externalDocUpdateUnsubs` Set to track subscriptions registered via `onDocUpdate()`
- Wrap provider's unsubscribe in `onDocUpdate()` so manual unsubscribe removes from tracking
- Iterate and call all tracked unsubscribes in `destroy()`

### Tests (`tests/domain/entities/room.test.ts`)
- Add test: manual unsubscribe calls provider's unsubscribe
- Add test: `destroy()` cleans up all external `onDocUpdate` listeners
- Add test: manually unsubscribed listeners are not double-unsubscribed on `destroy()`

## Checklist
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run test` passes
