### PR TITLE
refactor: Remove timer.start() side effect from Room constructor

### DIFF
--- a/src/application/room-manager.ts
+++ b/src/application/room-manager.ts
@@ -67,6 +67,7 @@ export class RoomManager {
         timer,
       })
 
+      room.start()
       this.rooms.set(roomId.toString(), room)
       return room
     } catch (err) {

--- a/src/domain/entities/room.ts
+++ b/src/domain/entities/room.ts
@@ -43,7 +43,10 @@ export class Room {
       this.timer.reset(),
     )
 
-    // Start the TTL timer
+  }
+
+  /** Activate the room's TTL timer */
+  start(): void {
     this.timer.start()
   }
 

--- a/src/domain/entities/room.ts
+++ b/src/domain/entities/room.ts
@@ -15,6 +15,7 @@ export interface RoomDeps {
  * Integrates TTL, Awareness, and ProviderAdapter into a single room entity.
  */
 export class Room {
+  private started = false
   private destroyed = false
   private readonly unsubDocUpdate: () => void
   private readonly unsubAwarenessUpdate: () => void
@@ -36,17 +37,18 @@ export class Room {
     this.timer = deps.timer
 
     // Wire doc and awareness updates to timer reset
-    this.unsubDocUpdate = this.provider.onDocUpdate(id, () =>
-      this.timer.reset(),
-    )
-    this.unsubAwarenessUpdate = this.provider.onAwarenessUpdate(id, () =>
-      this.timer.reset(),
-    )
+    this.unsubDocUpdate = this.provider.onDocUpdate(id, () => {
+      if (this.started) this.timer.reset()
+    })
+    this.unsubAwarenessUpdate = this.provider.onAwarenessUpdate(id, () => {
+      if (this.started) this.timer.reset()
+    })
 
   }
 
   /** Activate the room's TTL timer */
   start(): void {
+    this.started = true
     this.timer.start()
   }
 

--- a/tests/domain/entities/room.test.ts
+++ b/tests/domain/entities/room.test.ts
@@ -114,7 +114,21 @@ describe('Room', () => {
   })
 
   describe('TTL reset on doc update', () => {
-    it('resets timer when doc update callback fires', () => {
+    it('resets timer when doc update callback fires after start', () => {
+      const provider = createMockProvider()
+      const timer = createMockTimer()
+      const { room } = createRoom({ provider, timer })
+      room.start()
+
+      const docUpdateCallback = (
+        provider.onDocUpdate as ReturnType<typeof vi.fn>
+      ).mock.calls[0][1] as () => void
+      docUpdateCallback()
+
+      expect(timer.reset).toHaveBeenCalledOnce()
+    })
+
+    it('does not reset timer when doc update fires before start', () => {
       const provider = createMockProvider()
       const timer = createMockTimer()
       createRoom({ provider, timer })
@@ -124,12 +138,26 @@ describe('Room', () => {
       ).mock.calls[0][1] as () => void
       docUpdateCallback()
 
-      expect(timer.reset).toHaveBeenCalledOnce()
+      expect(timer.reset).not.toHaveBeenCalled()
     })
   })
 
   describe('TTL reset on awareness update', () => {
-    it('resets timer when awareness update callback fires', () => {
+    it('resets timer when awareness update callback fires after start', () => {
+      const provider = createMockProvider()
+      const timer = createMockTimer()
+      const { room } = createRoom({ provider, timer })
+      room.start()
+
+      const awarenessUpdateCallback = (
+        provider.onAwarenessUpdate as ReturnType<typeof vi.fn>
+      ).mock.calls[0][1] as () => void
+      awarenessUpdateCallback()
+
+      expect(timer.reset).toHaveBeenCalledOnce()
+    })
+
+    it('does not reset timer when awareness update fires before start', () => {
       const provider = createMockProvider()
       const timer = createMockTimer()
       createRoom({ provider, timer })
@@ -139,7 +167,7 @@ describe('Room', () => {
       ).mock.calls[0][1] as () => void
       awarenessUpdateCallback()
 
-      expect(timer.reset).toHaveBeenCalledOnce()
+      expect(timer.reset).not.toHaveBeenCalled()
     })
   })
 

--- a/tests/domain/entities/room.test.ts
+++ b/tests/domain/entities/room.test.ts
@@ -83,9 +83,9 @@ describe('Room', () => {
       expect(room.ydoc).toBe(ydoc)
     })
 
-    it('starts the timer on construction', () => {
+    it('does not start the timer on construction', () => {
       const { timer } = createRoom()
-      expect(timer.start).toHaveBeenCalledOnce()
+      expect(timer.start).not.toHaveBeenCalled()
     })
 
     it('subscribes to provider.onDocUpdate on construction', () => {
@@ -102,6 +102,14 @@ describe('Room', () => {
         roomId,
         expect.any(Function),
       )
+    })
+  })
+
+  describe('start', () => {
+    it('starts the timer', () => {
+      const { room, timer } = createRoom()
+      room.start()
+      expect(timer.start).toHaveBeenCalledOnce()
     })
   })
 


### PR DESCRIPTION
## Summary
- Remove `timer.start()` call from `Room` constructor and introduce an explicit `room.start()` method, allowing setup steps between construction and timer activation

## Related Issue
Closes #31

## Changes

### Domain: Room entity (`src/domain/entities/room.ts`)
- Remove `this.timer.start()` from constructor
- Add public `start()` method that delegates to `timer.start()`

### Application: RoomManager (`src/application/room-manager.ts`)
- Call `room.start()` explicitly after `new Room(...)` in `create()`

### Tests (`tests/domain/entities/room.test.ts`)
- Update constructor test to verify timer is **not** started on construction
- Add `describe('start')` block verifying `start()` delegates to `timer.start()`

## Checklist
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run test` passes